### PR TITLE
Fix bootstrap3 checkboxes by removing form-control class.

### DIFF
--- a/distribution/templates/bootstrap3.js
+++ b/distribution/templates/bootstrap3.js
@@ -54,6 +54,8 @@
   ');
 
   Form.editors.Base.prototype.className = 'form-control';
+  Form.editors.Checkbox.prototype.className = 'checkbox';
+  Form.editors.Checkboxes.prototype.className = 'checkbox';
   Form.Field.errorClassName = 'has-error';
 
 


### PR DESCRIPTION
Fixes issue #385.
